### PR TITLE
Implemented the Failed event on UnitOfWork.

### DIFF
--- a/src/Abp.EntityFramework/EntityFramework/Uow/EfUnitOfWork.cs
+++ b/src/Abp.EntityFramework/EntityFramework/Uow/EfUnitOfWork.cs
@@ -108,12 +108,28 @@ namespace Abp.EntityFramework.Uow
 
         protected void SaveChangesInDbContext(DbContext dbContext)
         {
-            dbContext.SaveChanges();
+            try
+            {
+                dbContext.SaveChanges();
+            }
+            catch (Exception saveChangesException)
+            {
+                OnFailed(saveChangesException);
+                throw;
+            }
         }
 
         protected async Task SaveChangesInDbContextAsync(DbContext dbContext)
         {
-            await dbContext.SaveChangesAsync();
+            try
+            {
+                await dbContext.SaveChangesAsync();
+            }
+            catch (Exception saveChangesException)
+            {
+                OnFailed(saveChangesException);
+                throw;
+            }
         }
     }
 }

--- a/src/Abp/Abp.csproj
+++ b/src/Abp/Abp.csproj
@@ -169,6 +169,7 @@
     <Compile Include="Domain\Uow\InnerUnitOfWorkCompleteHandle.cs" />
     <Compile Include="Domain\Uow\NullUnitOfWork.cs" />
     <Compile Include="Domain\Uow\UnitOfWorkDefaultOptions.cs" />
+    <Compile Include="Domain\Uow\UnitOfWorkFailedEventArgs.cs" />
     <Compile Include="Domain\Uow\UnitOfWorkManager.cs" />
     <Compile Include="Domain\Uow\UnitOfWorkOptions.cs" />
     <Compile Include="Events\Bus\Entities\EntityChangedEventData.cs" />

--- a/src/Abp/Domain/Uow/UnitOfWorkBase.cs
+++ b/src/Abp/Domain/Uow/UnitOfWorkBase.cs
@@ -42,6 +42,12 @@ namespace Abp.Domain.Uow
         }
 
         /// <inheritdoc/>
+        protected void OnFailed(Exception exception)
+        {
+            Failed.InvokeSafely(this, new UnitOfWorkFailedEventArgs(exception));
+        }
+
+        /// <inheritdoc/>
         public abstract void SaveChanges();
 
         /// <inheritdoc/>

--- a/src/Abp/Domain/Uow/UnitOfWorkFailedEventArgs.cs
+++ b/src/Abp/Domain/Uow/UnitOfWorkFailedEventArgs.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Abp.Domain.Uow
+{
+    public class UnitOfWorkFailedEventArgs : EventArgs
+    {
+        public Exception Exception { get; private set; }
+
+        public UnitOfWorkFailedEventArgs(Exception exception)
+        {
+            Exception = exception;
+        }
+    }
+}


### PR DESCRIPTION
Implemented the Failed event on UnitOfWork.  This was necessary in order to capture any exceptions that may occur upon automatic SaveChanges call on the UnitOfWork after an ApplicationService call.  Created an OnFailed protected method in UnitOfWorkBase which derived classes can call to fire the event on failure.

N.B. I implemented the usage of this in my project using an interceptor on the application services to attach to the current UOW Failed event.  If a DbException occurs on SaveChanges (such as a FK constraint on delete), I can now capture the exception centrally and transform it into a user friendly exception.
