### PR TITLE
Implemented explicit publishing of Enums and Constants through AbpScripts/GetScripts

### DIFF
--- a/src/Abp.Web.Mvc/Web/Mvc/Controllers/AbpScriptsController.cs
+++ b/src/Abp.Web.Mvc/Web/Mvc/Controllers/AbpScriptsController.cs
@@ -6,6 +6,7 @@ using Abp.Web.Localization;
 using Abp.Web.Navigation;
 using Abp.Web.Sessions;
 using Abp.Web.Settings;
+using Abp.Web.Constants;
 
 namespace Abp.Web.Mvc.Controllers
 {
@@ -20,6 +21,7 @@ namespace Abp.Web.Mvc.Controllers
         private readonly ILocalizationScriptManager _localizationScriptManager;
         private readonly IAuthorizationScriptManager _authorizationScriptManager;
         private readonly ISessionScriptManager _sessionScriptManager;
+        private readonly IConstantScriptManager _constantScriptManager;
 
         /// <summary>
         /// Constructor.
@@ -28,14 +30,16 @@ namespace Abp.Web.Mvc.Controllers
             ISettingScriptManager settingScriptManager, 
             INavigationScriptManager navigationScriptManager, 
             ILocalizationScriptManager localizationScriptManager, 
-            IAuthorizationScriptManager authorizationScriptManager, 
-            ISessionScriptManager sessionScriptManager)
+            IAuthorizationScriptManager authorizationScriptManager,
+            ISessionScriptManager sessionScriptManager, 
+            IConstantScriptManager constantScriptManager)
         {
             _settingScriptManager = settingScriptManager;
             _navigationScriptManager = navigationScriptManager;
             _localizationScriptManager = localizationScriptManager;
             _authorizationScriptManager = authorizationScriptManager;
             _sessionScriptManager = sessionScriptManager;
+            _constantScriptManager = constantScriptManager;
         }
 
         /// <summary>
@@ -59,6 +63,9 @@ namespace Abp.Web.Mvc.Controllers
             sb.AppendLine();
             
             sb.AppendLine(await _settingScriptManager.GetScriptAsync());
+
+            sb.AppendLine();
+            sb.AppendLine(_constantScriptManager.GetScript());
 
             return Content(sb.ToString(), "application/x-javascript", Encoding.UTF8);
         }

--- a/src/Abp.Web/Abp.Web.csproj
+++ b/src/Abp.Web/Abp.Web.csproj
@@ -55,6 +55,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Web\Constants\ConstantScriptManager.cs" />
+    <Compile Include="Web\Constants\IConstantScriptManager.cs" />
     <Compile Include="Web\Models\AjaxResponse.cs" />
     <Compile Include="Web\Models\ErrorInfoBuilder.cs" />
     <Compile Include="Web\Models\IErrorInfoBuilder.cs" />

--- a/src/Abp.Web/Web/Constants/ConstantScriptManager.cs
+++ b/src/Abp.Web/Web/Constants/ConstantScriptManager.cs
@@ -1,0 +1,179 @@
+﻿using Abp.Constants;
+using Abp.Dependency;
+using Abp.Extensions;
+using Abp.Reflection;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Abp.Web.Constants
+{
+    /// <summary>   Generates JavaScript for constants and enums 
+    ///             marked with the PublishAttribute. </summary>
+    public class ConstantScriptManager : IConstantScriptManager, ISingletonDependency
+    {
+        /// <summary>   Generates a JavaScript object representing the Enum.  Each Enum value is
+        ///             exported as well as a values array that can be used in drop down lists.  
+        ///             The values array includes an automatically named locallized string that
+        ///             can be used for localization.  The localized name is in the format
+        ///             Enum_[Parent_][EnumName]_[ValueName].</summary>
+        ///
+        /// <exception cref="ArgumentException"> Thrown if the type is not an Enum</exception>
+        ///
+        /// <param name="enumType">        The Enum Type to process. </param>
+        /// <param name="parent">   An optional parent class name with which 
+        ///                         to group the enum values. </param>
+        ///
+        /// <returns>   The enum script. </returns>
+        private string GetEnumScript(Type enumType, string parent = null)
+        {
+            string resourcePrefix = "Enum_";
+            var script = new StringBuilder();
+            if (!enumType.IsEnum)
+            {
+                throw new ArgumentException("enumType is not an Enum.", "enumType");
+            }
+            script.Append("    abp.constant.");
+            /**
+             * If a parent class is defined, add the extra level.
+             * The assumption is that the parent class would have already
+             * been declared first in the script.
+             */
+            if (!string.IsNullOrEmpty(parent))
+            {
+                parent = parent.Trim('.');
+                resourcePrefix += parent + "_";
+                script.Append(parent.ToCamelCase());
+                script.Append(".");
+            }
+            resourcePrefix += enumType.Name + "_";
+            script.Append(enumType.Name.ToCamelCase());
+            script.Append(" = {");
+
+            // Export all enum values
+            int added = 0;
+            var valuesArray = new StringBuilder();
+            valuesArray.Append("        values: [");
+            foreach (var enumValue in enumType.GetEnumValues())
+            {
+                if (added > 0)
+                {
+                    script.AppendLine(",");
+                    valuesArray.AppendLine(",");
+                }
+                else
+                {
+                    script.AppendLine();
+                    valuesArray.AppendLine();
+                }
+                string name = enumType.GetEnumName(enumValue);
+                long value = Convert.ToInt64(enumValue);
+                script.Append("        " + name.ToCamelCase() + ": " + value + "");
+                valuesArray.Append("            { name: '" + name + "', value: " + value + ", localizedName: '" + resourcePrefix + name + "' }");
+                ++added;
+            }
+            valuesArray.Append("]");
+            if (added > 0)
+            {
+                script.AppendLine(",");
+            }
+            else
+            {
+                script.AppendLine();
+            }
+            script.AppendLine(valuesArray.ToString());
+            script.AppendLine("    };");
+            return script.ToString();
+        }
+
+        public string GetScript()
+        {
+            var script = new StringBuilder();
+
+            script.AppendLine("(function(){");
+            script.AppendLine("    abp.constant = abp.constant || {};");
+
+            /**
+             * Use reflection to find all Enums & Classes marked as publish
+             */
+            TypeFinder finder = new TypeFinder();
+            Type[] potentialPublishTypes = finder.Find(q => (q.IsClass || q.IsEnum));
+
+            foreach (Type potentialPublishType in potentialPublishTypes)
+            {
+                // Check for publish attribute
+                PublishAttribute publishAttr = TypeDescriptor.GetAttributes(potentialPublishType)
+                    .OfType<PublishAttribute>()
+                    .FirstOrDefault();
+                if (publishAttr != null &&
+                    publishAttr.Export)
+                {
+                    if (potentialPublishType.IsEnum)
+                    {
+                        script.Append(GetEnumScript(potentialPublishType));
+                    }
+                    else
+                    {
+                        script.Append("    abp.constant." + potentialPublishType.Name.ToCamelCase() + " = {");
+                        // Export all public constants & readonly values
+                        var added = 0;
+                        foreach (var potentialConstantField in potentialPublishType.GetFields(BindingFlags.Public | BindingFlags.DeclaredOnly | BindingFlags.Static))
+                        {
+                            if (potentialConstantField.IsLiteral)
+                            {
+                                object constantValue = potentialConstantField.GetRawConstantValue();
+                                if (constantValue != null)
+                                {
+                                    if (added > 0)
+                                    {
+                                        script.AppendLine(",");
+                                    }
+                                    else
+                                    {
+                                        script.AppendLine();
+                                    }
+                                    string value = constantValue.ToString();
+                                    if (potentialConstantField.FieldType == typeof(string))
+                                    {
+                                        // If this is a string type, enclose in quotes.
+                                        value = string.Format("'{0}'", constantValue);
+                                    }
+                                    script.Append("        " + potentialConstantField.Name.ToCamelCase() + ": " + value);
+                                    ++added;
+                                }
+                            }
+                        }
+                        script.AppendLine();
+                        script.AppendLine("    };");
+                    }
+
+                    // Export any nested enums
+                    foreach (var nestedType in potentialPublishType.GetNestedTypes())
+                    {
+                        if (nestedType.IsEnum)
+                        {
+                            PublishAttribute nestedPublishAttr = TypeDescriptor.GetAttributes(nestedType)
+                                .OfType<PublishAttribute>()
+                                .FirstOrDefault();
+                            if (nestedPublishAttr == null ||
+                                nestedPublishAttr.Export == true)
+                            {
+                                script.Append(GetEnumScript(nestedType, potentialPublishType.Name));
+                            }
+                        }
+                    }
+                }
+            }
+
+            script.AppendLine();
+            script.Append("})();");
+
+            return script.ToString();
+        }
+    }
+
+}

--- a/src/Abp.Web/Web/Constants/IConstantScriptManager.cs
+++ b/src/Abp.Web/Web/Constants/IConstantScriptManager.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Abp.Web.Constants
+{
+    /// <summary>
+    /// Define interface to get constants and enumerations injected into a script
+    /// </summary>
+    public interface IConstantScriptManager
+    {
+        /// <summary>
+        /// Gets Javascript that contains setting values.
+        /// </summary>
+        string GetScript();
+    }
+}

--- a/src/Abp/Abp.csproj
+++ b/src/Abp/Abp.csproj
@@ -149,6 +149,7 @@
     <Compile Include="Configuration\Startup\ModuleConfigurations.cs" />
     <Compile Include="Configuration\Startup\NavigationConfiguration.cs" />
     <Compile Include="Configuration\Startup\SettingsConfiguration.cs" />
+    <Compile Include="Constants\PublishAttribute.cs" />
     <Compile Include="DateTimeRange.cs" />
     <Compile Include="Domain\Entities\Auditing\AuditedEntity.cs" />
     <Compile Include="Domain\Entities\Auditing\CreationAuditedEntity.cs" />

--- a/src/Abp/Constants/PublishAttribute.cs
+++ b/src/Abp/Constants/PublishAttribute.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Abp.Constants
+{
+    /// <summary>   Attribute for enums and classes to indicate whether or not
+    ///             to publish values and constants publically. </summary>
+    [AttributeUsage(AttributeTargets.Enum | AttributeTargets.Class)]
+    public class PublishAttribute : Attribute
+    {
+        /// <summary>   Define whether or not to publish an enum or a 
+        ///             class's public constants </summary>
+        ///
+        /// <param name="export">   true to export. </param>
+        public PublishAttribute(bool export = true)
+        {
+            Export = export;
+        }
+
+        /// <summary>   Gets or sets a value indicating whether the export. </summary>
+        ///
+        /// <value> true if export, false if not. </value>
+        public bool Export { get; private set; }
+    }
+}


### PR DESCRIPTION
PublishAttribute can be used to mark enums and classes to be eligible for publishing. CosntantScriptManager is used to generate JavaScript objects of the published classes and enums. For enum types, the JavaScript object includes the constant values as well as an Array of names, values, and localized string keys to be used for drop down lists or other list type controls.

Usage:

```
[Abp.Constants.Publish()]
public enum Status
{
    NotStarted = 0,
    InProgress = 10,
    Draft = 20,
    Cancelled = 90,
    Completed = 100
}
```

would expose the following the AbpScript

```
abp.constant.status = {
    notStarted: 0,
    inProgress: 10,
    draft: 20,
    cancelled: 90,
    completed: 100,
    values: [
        { name: 'NotStarted', value: 0, localizedName: 'Enum_Status_NotStarted' },
        { name: 'InProgress', value: 10, localizedName: 'Enum_Status_InProgress' },
        { name: 'Draft', value: 20, localizedName: 'Enum_Status_Draft' },
        { name: 'Cancelled', value: 90, localizedName: 'Enum_Status_Cancelled' },
        { name: 'Completed', value: 100, localizedName: 'Enum_Status_Completed' }]
};
```
